### PR TITLE
Expect text token response

### DIFF
--- a/src/app/modules/ngx-braintree/ngx-braintree.component.ts
+++ b/src/app/modules/ngx-braintree/ngx-braintree.component.ts
@@ -60,6 +60,7 @@ export class NgxBraintreeComponent implements OnInit {
         this.interval = setInterval(() => { this.createDropin(); }, 0);
       }, (error) => {
         this.clientTokenNotReceived = true;
+        console.log(error);
         console.error(`Client token not received.
           Please make sure your braintree server api is configured properly, running and accessible.`);
       });

--- a/src/app/modules/ngx-braintree/ngx-braintree.component.ts
+++ b/src/app/modules/ngx-braintree/ngx-braintree.component.ts
@@ -60,7 +60,6 @@ export class NgxBraintreeComponent implements OnInit {
         this.interval = setInterval(() => { this.createDropin(); }, 0);
       }, (error) => {
         this.clientTokenNotReceived = true;
-        console.log(error);
         console.error(`Client token not received.
           Please make sure your braintree server api is configured properly, running and accessible.`);
       });

--- a/src/app/modules/ngx-braintree/ngx-braintree.service.ts
+++ b/src/app/modules/ngx-braintree/ngx-braintree.service.ts
@@ -12,7 +12,7 @@ export class NgxBraintreeService {
 
   getClientToken(clientTokenURL: string): Observable<string> {
     return this.http
-      .get(clientTokenURL)
+      .get(clientTokenURL, {responseType: 'text'})
       .map((response: any) => {
         return response;
       })


### PR DESCRIPTION
The Braintree Node.js documentation demos sending the client token as raw text. For users who followed their documentation with Node.js, Angular's http library would fail to parse the text response. Adding `{responseType: 'text'}` to the GET request fixes this.

The http parsing bug is discussed [here](https://github.com/angular/angular/issues/18680).
Braintree Node.js documentation found [here](https://developers.braintreepayments.com/start/hello-server/node).