### PR TITLE
consistent request and response types added.

### DIFF
--- a/src/app/modules/ngx-braintree/ngx-braintree.service.ts
+++ b/src/app/modules/ngx-braintree/ngx-braintree.service.ts
@@ -12,9 +12,9 @@ export class NgxBraintreeService {
 
   getClientToken(clientTokenURL: string): Observable<string> {
     return this.http
-      .get(clientTokenURL, {responseType: 'text'})
+      .get(clientTokenURL, { responseType: 'json' })
       .map((response: any) => {
-        return response;
+        return response.token;
       })
       .catch((error) => {
         return Observable.throw(error);
@@ -22,9 +22,8 @@ export class NgxBraintreeService {
   }
 
   createPurchase(createPurchaseURL: string, nonce: string): Observable<any> {
-    const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
     return this.http
-      .post(createPurchaseURL, { nonce: nonce }, { 'headers': headers })
+      .post(createPurchaseURL, { nonce: nonce })
       .map((response: any) => {
         return response;
       });


### PR DESCRIPTION
To maintain consistency for getClientToken and createPurchase methods' request and response types, json, application/json types have been added respectively. It is now required that the server side methods that provides the client token send the response in a json format with token as the key and value as the client token as shown below:
{"token":"idmVubW8iOiJvZmYifQ=="}

Similarly, the createPurchase method sends the nonce to the server as shown below:
{"nonce":"0bb03050-2ecd-0553-263d-ad3bc4865391"}