### PR TITLE
Issue 96 - Update Braintree Drop-in Script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-braintree",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-braintree",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.config.json",

--- a/projects/ngx-braintree/src/lib/ngx-braintree.directive.ts
+++ b/projects/ngx-braintree/src/lib/ngx-braintree.directive.ts
@@ -13,7 +13,7 @@ export class NgxBraintreeDirective implements OnInit, OnDestroy {
   ngOnInit() {
     this.script = this.renderer.createElement('script');
     this.script.type = 'text/javascript';
-    this.script.src = 'https://js.braintreegateway.com/web/dropin/1.8.0/js/dropin.min.js';
+    this.script.src = 'https://js.braintreegateway.com/web/dropin/1.13.0/js/dropin.min.js';
     this.renderer.appendChild(this.document.body, this.script);
   }
 


### PR DESCRIPTION
The BrainTree Drop in UI Script is updated. Currently version 1.8.0 is being used and updated it to the latest version 1.13.0. PayPal can break when using versions older then 1.9.3.