### PR TITLE
peerDependencies: adding Angular 7

### DIFF
--- a/projects/ngx-braintree/package.json
+++ b/projects/ngx-braintree/package.json
@@ -2,7 +2,7 @@
   "name": "ngx-braintree",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
-    "@angular/core": "^6.0.0-rc.0 || ^6.0.0"
+    "@angular/common": "^6.0.0-rc.0 || ^6.0.0 || ^7.0.0",
+    "@angular/core": "^6.0.0-rc.0 || ^6.0.0 || ^7.0.0"
   }
 }


### PR DESCRIPTION
Plugin still works in Angular 7, did not encounter any bugs (yet)