### PR TITLE
Adding support for threeDParameters

### DIFF
--- a/projects/ngx-braintree/src/lib/models/index.ts
+++ b/projects/ngx-braintree/src/lib/models/index.ts
@@ -1,0 +1,1 @@
+export * from './threeDParameters';

--- a/projects/ngx-braintree/src/lib/models/threeDParameters.ts
+++ b/projects/ngx-braintree/src/lib/models/threeDParameters.ts
@@ -1,0 +1,26 @@
+export interface IThreeDParameters {
+    amount: string;
+    email?: string;
+    billingAddress?: IAddress;
+    additionalInformation?: IAdditionalInformation;
+}
+
+export interface IAddress {
+    givenName?: string;
+    surname?: string;
+    phoneNumber?: string;
+    streetAddress?: string;
+    extendedAddress?: string;
+    locality?: string;
+    region?: string;
+    postalCode?: string;
+    countryCodeAlpha2?: string;
+}
+
+export interface IAdditionalInformation {
+    workPhoneNumber?: string;
+    shippingGivenName?: string;
+    shippingSurname?: string;
+    shippingPhone?: string;
+    shippingAddress?: IAddress;
+}

--- a/projects/ngx-braintree/src/lib/ngx-braintree.component.ts
+++ b/projects/ngx-braintree/src/lib/ngx-braintree.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { NgxBraintreeService } from './ngx-braintree.service';
 import { ConfigureDropinService } from './configure-dropin.service';
+import { IThreeDParameters } from './models/threeDParameters';
 
 declare var braintree: any;
 
@@ -107,6 +108,7 @@ export class NgxBraintreeComponent implements OnInit {
   @Input() enabledStyle: any;
   @Input() disabledStyle: any;
   @Input() hideLoader = false;
+  @Input() threeDParameters: IThreeDParameters;
 
   clientToken: string;
   nonce: string;
@@ -167,6 +169,7 @@ export class NgxBraintreeComponent implements OnInit {
     if (typeof braintree !== 'undefined') {
       this.dropinConfig.authorization = this.clientToken;
       this.dropinConfig.container = '#dropin-container';
+      this.dropinConfig.threeDSecure = this.threeDParameters != null;
 
       if (this.showCardholderName) {
         this.configureDropinService.configureCardHolderName(this.dropinConfig);
@@ -213,7 +216,8 @@ export class NgxBraintreeComponent implements OnInit {
 
   pay(): void {
     if (this.instance) {
-      this.instance.requestPaymentMethod((err, payload) => {
+      const options = this.threeDParameters ? { threeDSecure: this.threeDParameters } : {};
+      this.instance.requestPaymentMethod(options, (err, payload) => {
         if (err) {
           console.error(err);
           this.errorMessage = err;

--- a/projects/ngx-braintree/src/lib/ngx-braintree.directive.ts
+++ b/projects/ngx-braintree/src/lib/ngx-braintree.directive.ts
@@ -13,7 +13,7 @@ export class NgxBraintreeDirective implements OnInit, OnDestroy {
   ngOnInit() {
     this.script = this.renderer.createElement('script');
     this.script.type = 'text/javascript';
-    this.script.src = 'https://js.braintreegateway.com/web/dropin/1.13.0/js/dropin.min.js';
+    this.script.src = 'https://js.braintreegateway.com/web/dropin/1.22.1/js/dropin.min.js';
     this.renderer.appendChild(this.document.body, this.script);
   }
 

--- a/projects/ngx-braintree/src/public_api.ts
+++ b/projects/ngx-braintree/src/public_api.ts
@@ -5,3 +5,4 @@
 export * from './lib/ngx-braintree.service';
 export * from './lib/ngx-braintree.component';
 export * from './lib/ngx-braintree.module';
+export * from './lib/models';


### PR DESCRIPTION
Adding support for threeDParameters to enable 3D Secure.

There is a new @Input() on the NgxBraintreeComponent that takes in the threeDParameters required by the 3D Secure functionality. Setting it automatically enables 3D Secure nonce.